### PR TITLE
Add memory barrier for mmio accessing

### DIFF
--- a/include/lib/mmio.h
+++ b/include/lib/mmio.h
@@ -31,36 +31,52 @@
 #ifndef __MMIO_H__
 #define __MMIO_H__
 
+#include <arch_helpers.h>
 #include <stdint.h>
 
 static inline void mmio_write_8(uintptr_t addr, uint8_t value)
 {
+	dsb();
 	*(volatile uint8_t*)addr = value;
 }
 
 static inline uint8_t mmio_read_8(uintptr_t addr)
 {
-	return *(volatile uint8_t*)addr;
+	uint8_t val;
+
+	val = *(volatile uint8_t*)addr;
+	dsb();
+	return val;
 }
 
 static inline void mmio_write_32(uintptr_t addr, uint32_t value)
 {
+	dsb();
 	*(volatile uint32_t*)addr = value;
 }
 
 static inline uint32_t mmio_read_32(uintptr_t addr)
 {
-	return *(volatile uint32_t*)addr;
+	uint32_t val;
+
+	val = *(volatile uint32_t*)addr;
+	dsb();
+	return val;
 }
 
 static inline void mmio_write_64(uintptr_t addr, uint64_t value)
 {
+	dsb();
 	*(volatile uint64_t*)addr = value;
 }
 
 static inline uint64_t mmio_read_64(uintptr_t addr)
 {
-	return *(volatile uint64_t*)addr;
+	uint64_t val;
+
+	val = *(volatile uint64_t*)addr;
+	dsb();
+	return val;
 }
 
 #endif /* __MMIO_H__ */


### PR DESCRIPTION
Add memory barrier for mmio write and read operations, so that it will
be much stable for initialization.

Signed-off-by: Leo Yan leo.yan@linaro.org
