### PR TITLE
hikey usb.h: fix alignment issue

### DIFF
--- a/plat/hikey/include/usb.h
+++ b/plat/hikey/include/usb.h
@@ -776,7 +776,7 @@ struct usb_endpoint_descriptor {
         unsigned char  bmAttributes;
         unsigned short wMaxPacketSize;
         unsigned char  bInterval;
-} __attribute__ ((packed));
+};
 
 #define USB_DT_ENDPOINT_SIZE            7
 #define USB_DT_ENDPOINT_AUDIO_SIZE      9       /* Audio extension */


### PR DESCRIPTION
Fix bug #2 as mentioned by Jerome Forissier in https://lists.96boards.org/pipermail/dev/2015-March/000138.html

Signed-off-by: Koen Kooi koen.kooi@linaro.org;
