### PR TITLE
HiKey: pll.c: do not access memory at address 0x0

### DIFF
--- a/plat/hikey/pll.c
+++ b/plat/hikey/pll.c
@@ -1119,6 +1119,15 @@ void hi6220_pll_init(void)
 	init_freq();
 	init_ddr();
 	init_ddrc_qos();
+
+	/*
+	 * Test memory access. Do not use address 0x0 because the compiler
+	 * may assume it is not a valid address and generate incorrect code
+	 * (GCC 4.9.1 without -fno-delete-null-pointer-checks for instance).
+	 */
+	mmio_write_32(0x4, 0xa5a55a5a);
+	INFO("ddr test value:0x%x\n", mmio_read_32(0x4));
+
 	init_mmc_pll();
 	reset_mmc0_clk();
 	init_media_clk();

--- a/plat/hikey/pll.c
+++ b/plat/hikey/pll.c
@@ -1119,10 +1119,6 @@ void hi6220_pll_init(void)
 	init_freq();
 	init_ddr();
 	init_ddrc_qos();
-
-	mmio_write_32(0x0, 0xa5a55a5a);
-	INFO("ddr test value:0x%x\n", mmio_read_32(0x0));
-
 	init_mmc_pll();
 	reset_mmc0_clk();
 	init_media_clk();


### PR DESCRIPTION
This commit deletes the memory access test done in BL1 immediately after
DDR initialization. The test is performed at address 0x0, which is valid
but may be subject to an unwanted compiler optimization. GCC 4.9, for
instance, assumes that programs cannot safely dereference null pointers
and will generate a brk instruction, resulting in a BL1 hang.

Using -fno-delete-null-pointer-checks would be another option, but it is
not justified because we don't really need to access address 0x0 anyway.

Signed-off-by: Jerome Forissier jerome.forissier@linaro.org
