### PR TITLE
hikey: ATF: Add memory barrier for pll and timer init

### DIFF
--- a/plat/hikey/drivers/sp804_timer.c
+++ b/plat/hikey/drivers/sp804_timer.c
@@ -29,6 +29,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <arch_helpers.h>
 #include <console.h>
 #include <debug.h>
 #include <errno.h>
@@ -50,6 +51,8 @@ void hi6220_timer_init(void)
 		mmio_write_32(AO_SC_TIMER_EN0, data);
 		data = mmio_read_32(AO_SC_TIMER_EN0);
 	}
+	dsb();
+
 	/* enable the pclk of dual timer0 */
 	data = mmio_read_32(AO_SC_PERIPH_CLKSTAT4);
 	while (!(data & PCLK_TIMER1) || !(data & PCLK_TIMER0)) {
@@ -67,16 +70,19 @@ void hi6220_timer_init(void)
 	do {
 		data = mmio_read_32(AO_SC_PERIPH_RSTSTAT4);
 	} while ((data & PCLK_TIMER1) || (data & PCLK_TIMER0));
+	dsb();
 	
 	/* disable timer00 */
 	mmio_write_32(TIMER00_CONTROL, 0);
 	mmio_write_32(TIMER00_LOAD, 0xffffffff);
 	/* free running */
 	mmio_write_32(TIMER00_CONTROL, 0x82);
+	dsb();
 }
 
 static unsigned int get_timer_value(void)
 {
+	dsb();
 	return mmio_read_32(TIMER00_VALUE);
 }
 

--- a/plat/hikey/pll.c
+++ b/plat/hikey/pll.c
@@ -45,7 +45,7 @@ static void init_pll(void)
 {
 	unsigned int data;
 
-
+	dsb();
 	data = mmio_read_32((0xf7032000 + 0x000));
 	data |= 0x1;
 	mmio_write_32((0xf7032000 + 0x000), data);
@@ -53,7 +53,6 @@ static void init_pll(void)
 	do {
 		data = mmio_read_32((0xf7032000 + 0x000));
 	} while (!(data & (1 << 28)));
-
 
 	data = mmio_read_32((0xf7800000 + 0x000));
 	data &= ~0x007;
@@ -64,6 +63,7 @@ static void init_pll(void)
 		data = mmio_read_32((0xf7800000 + 0x014));
 		data &= 0x007;
 	} while (data != 0x004);
+	dsb();
 }
 
 static void init_freq(void)
@@ -104,10 +104,10 @@ static void init_freq(void)
 	dsb();
 	mdelay(10);
 
-
 	data = mmio_read_32((0xf6504000 + 0x054));
 	data &= ~((1 << 0) | (1 << 11));
 	mmio_write_32((0xf6504000 + 0x054), data);
+	dsb();
 	mdelay(10);
 
 	data = mmio_read_32((0xf7032000 + 0x104));
@@ -125,6 +125,7 @@ static void init_freq(void)
 		data &= (1 << 2);
 	} while (data != (1 << 2));
 
+	dsb();
 	data = mmio_read_32((0xf6504000 + 0x06c));
 	data &= ~0xffff;
 	data |= 0x56;
@@ -209,6 +210,7 @@ static void init_freq(void)
 		data = mmio_read_32((0xf7032000 + 0x100));
 		data &= (1 << 1);
 	} while (data != (1 << 1));
+	dsb();
 	mdelay(1000);
 
 	data = mmio_read_32((0xf6504000 + 0x054));
@@ -220,6 +222,7 @@ static void init_freq(void)
 	data &= ~((1 << 4) |
 			(3 << 12));
 	mmio_write_32((0xf7032000 + 0x110), data);
+	dsb();
 }
 
 static int cat_533mhz_800mhz(void)


### PR DESCRIPTION
Add memory barrier for pll and timer init, use this patch to replace add barriers for all mmio related operations.
