### PR TITLE
hikey: fix the error handling for wrong partition

### DIFF
--- a/plat/hikey/partitions.c
+++ b/plat/hikey/partitions.c
@@ -221,9 +221,9 @@ int get_partition(void)
 		if (ret)
 			break;
 	}
+exit:
 	io_close(img_handle);
 	update_fip_spec();
 	dump_entries();
-exit:
 	return result;
 }


### PR DESCRIPTION
If the wrong partition is got, especially for the new board, current
code just exit without closing file handler on storage device. So
append the missing close operation if there's a failure on accessing
partition table.

Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
