### PR TITLE
Report error info when load BL30 failed

### DIFF
--- a/bl2/bl2_main.c
+++ b/bl2/bl2_main.c
@@ -417,7 +417,8 @@ void bl2_main(void)
 	e = load_bl30();
 	if (e) {
 		ERROR("Failed to load BL3-0 (%i)\n", e);
-		panic();
+		ERROR("Pls burn mcu image:\n");
+		ERROR("  sudo fastboot flash mcuimage mcuimage.bin\n");
 	}
 
 	/* Perform platform setup in BL2 after loading BL3-0 */


### PR DESCRIPTION
This is a temporary fix, when load BL30 image failed it will just report
the error rather than run into panic. Will fix this issue when we move
mcu image from fip into its dedicated partition.

Signed-off-by: Leo Yan leo.yan@linaro.org
