### PR TITLE
hikey: refresh partition after ptable flushed

### DIFF
--- a/plat/hikey/plat_io_storage.c
+++ b/plat/hikey/plat_io_storage.c
@@ -516,6 +516,7 @@ int flush_user_images(char *cmdbuf, unsigned long img_addr,
 						img_addr + fp, offset, length);
 			fp += entries[i].count * 512;
 		}
+		get_partition();
 		break;
 	case IO_FAIL:
 		WARN("failed to parse entries in user image.\n");


### PR DESCRIPTION
Refresh partition table if ptable image is flushed into emmc device.

Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
