### PR TITLE
hikey: reserve top 16MB for optee

### DIFF
--- a/plat/hikey/include/platform_def.h
+++ b/plat/hikey/include/platform_def.h
@@ -173,7 +173,7 @@
 /*******************************************************************************
  * Load address of BL3-3 in the HiKey port
  ******************************************************************************/
-#define NS_IMAGE_OFFSET			(DRAM_BASE + 0x37000000)  /* 880MB */
+#define NS_IMAGE_OFFSET			(DRAM_BASE + 0x35000000)  /* 848MB */
 
 /*******************************************************************************
  * Platform specific page table and MMU setup constants


### PR DESCRIPTION
Reserve top memory (0x3F00_0000~0x3FFF_FFFC) in DRAM for OPTEE.

Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
