### PR TITLE
Hikey: Enable hotplug with mailbox emulation

### DIFF
--- a/include/bl31/services/psci.h
+++ b/include/bl31/services/psci.h
@@ -216,6 +216,7 @@ typedef struct spd_pm_ops {
 /*******************************************************************************
  * Function & Data prototypes
  ******************************************************************************/
+void psci_program_mailbox(uint64_t mpidr, uint64_t address);
 unsigned int psci_version(void);
 int psci_affinity_info(unsigned long, unsigned int);
 int psci_migrate(unsigned long);

--- a/services/std_svc/psci/psci_common.c
+++ b/services/std_svc/psci/psci_common.c
@@ -61,6 +61,23 @@ __attribute__ ((section("tzfw_coherent_mem")))
  ******************************************************************************/
 const plat_pm_ops_t *psci_plat_pm_ops;
 
+typedef volatile struct psci_mailbox {
+	unsigned long value
+	__attribute__((__aligned__(CACHE_WRITEBACK_GRANULE)));
+} psci_mailbox_t;
+
+psci_mailbox_t psci_mboxes[PLATFORM_CORE_COUNT];
+
+void psci_program_mailbox(uint64_t mpidr, uint64_t address)
+{
+	uint64_t linear_id;
+
+	linear_id = platform_get_core_pos(mpidr);
+	psci_mboxes[linear_id].value = address;
+	flush_dcache_range((unsigned long)&psci_mboxes[linear_id],
+			   sizeof(unsigned long));
+}
+
 /*******************************************************************************
  * This function is passed an array of pointers to affinity level nodes in the
  * topology tree for an mpidr. It iterates through the nodes to find the highest

--- a/services/std_svc/psci/psci_entry.S
+++ b/services/std_svc/psci/psci_entry.S
@@ -32,10 +32,12 @@
 #include <asm_macros.S>
 #include <psci.h>
 #include <xlat_tables.h>
+#include <gic_v2.h>
 
 	.globl	psci_aff_on_finish_entry
 	.globl	psci_aff_suspend_finish_entry
 	.globl	psci_power_down_wfi
+	.globl  psci_mboxes
 
 	/* -----------------------------------------------------
 	 * This cpu has been physically powered up. Depending
@@ -165,8 +167,31 @@ psci_aff_common_finish_entry:
 	 * --------------------------------------------
 	 */
 func psci_power_down_wfi
+
+	mrs	x2, scr_el3
+	orr	x2, x2, #(SCR_IRQ_BIT | SCR_FIQ_BIT)	// Enable IRQ
+	msr	scr_el3, x2
+	dsb	sy
+
+	ldr     x1, =GICC_BASE
+	ldr	w0, [x1, #GICC_CTLR]
+	bic	w0, w0, #(IRQ_BYP_DIS_GRP1 | FIQ_BYP_DIS_GRP1)
+	bic	w0, w0, #(IRQ_BYP_DIS_GRP0 | FIQ_BYP_DIS_GRP0)
+	orr	w0, w0, #(ENABLE_GRP0 | ENABLE_GRP1)
+	str	w0, [x1, #GICC_CTLR]
+	dsb	sy
+
+	bl	disable_mmu_icache_el3
+
+wfi_spill:
 	dsb	sy		// ensure write buffer empty
 	wfi
-wfi_spill:
-	b	wfi_spill
 
+	mrs	x0, mpidr_el1
+	ldr	x10, =psci_mboxes
+	bl	platform_get_core_pos
+	lsl	x0, x0, #CACHE_WRITEBACK_SHIFT
+	ldr	x0, [x10, x0]
+	cbz	x0, wfi_spill
+
+	blr	x0		// jump to secure entry point


### PR DESCRIPTION
We can use s/w emulation method to enable hotplug in ATF; when the cpu run into WFI it will not really to be powered off, so when next time it exit from wfi we can use the mailbox to tell cpu the secure entry point; so the cpu can continue to run with this entry point.
