### PR TITLE
pll: add dsb after media pll clock init

### DIFF
--- a/plat/hikey/pll.c
+++ b/plat/hikey/pll.c
@@ -1197,7 +1197,8 @@ void hi6220_pll_init(void)
 	reset_mmc0_clk();
 	init_media_clk();
 
+	dsb();
+
 	init_mmc1_pll();
 	reset_mmc1_clk();
-
 }


### PR DESCRIPTION
The dsb instruction must be added after media pll clock init.

Otherwise, we'll get this error message.

Platform exception reporting:
ESR_EL3: 0000000002000000
ELR_EL3: 00000000f9802ed0

Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
