### PR TITLE
hikey: add log for fastboot mode

### DIFF
--- a/plat/hikey/bl1_plat_setup.c
+++ b/plat/hikey/bl1_plat_setup.c
@@ -181,6 +181,7 @@ void bl1_platform_setup(void)
 	io_setup();
 	get_partition();
 	if (query_boot_mode()) {
+		NOTICE("Enter fastboot mode...\n");
 		flush_loader_image();
 		usb_download();
 	}


### PR DESCRIPTION
After run into fastboot mode, print out the info; so can easily check
main core's flow.

Signed-off-by: Leo Yan leo.yan@linaro.org
