### PR TITLE
hikey: be compatible without secondary ptable

### DIFF
--- a/plat/hikey/plat_io_storage.c
+++ b/plat/hikey/plat_io_storage.c
@@ -508,6 +508,8 @@ int flush_user_images(char *cmdbuf, unsigned long img_addr,
 					entries[i].flag);
 				return IO_NOT_SUPPORTED;
 			}
+			if (entries[i].count == 0)
+				continue;
 			length = entries[i].count * 512;
 			offset = MMC_BASE + entries[i].start * 512;
 			VERBOSE("i:%d, start:%x, count:%x\n",


### PR DESCRIPTION
If secondary ptable isn't included in ptable.img, the entry count should
be 0. So skip it when flush it to eMMC.

Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
