### PR TITLE
hikey: fix the exception in ddr initialization

### DIFF
--- a/plat/hikey/pll.c
+++ b/plat/hikey/pll.c
@@ -218,7 +218,7 @@ static void init_freq(void)
 	mmio_write_32((0xf7032000 + 0x110), data);
 }
 
-static int cat_533mhz_800mhz(void)
+int cat_533mhz_800mhz(void)
 {
 	unsigned int data, i;
 	unsigned int bdl[5];


### PR DESCRIPTION
Platform exception reporting:
ESR_EL3: 0000000002000000
ELR_EL3: 00000000f9803248

Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
