### PR TITLE
Power on hdmi

### DIFF
--- a/include/lib/mmio.h
+++ b/include/lib/mmio.h
@@ -37,6 +37,7 @@
 static inline void mmio_write_8(uintptr_t addr, uint8_t value)
 {
 	dsb();
+	isb();
 	*(volatile uint8_t*)addr = value;
 }
 
@@ -46,12 +47,14 @@ static inline uint8_t mmio_read_8(uintptr_t addr)
 
 	val = *(volatile uint8_t*)addr;
 	dsb();
+	isb();
 	return val;
 }
 
 static inline void mmio_write_32(uintptr_t addr, uint32_t value)
 {
 	dsb();
+	isb();
 	*(volatile uint32_t*)addr = value;
 }
 
@@ -61,12 +64,14 @@ static inline uint32_t mmio_read_32(uintptr_t addr)
 
 	val = *(volatile uint32_t*)addr;
 	dsb();
+	isb();
 	return val;
 }
 
 static inline void mmio_write_64(uintptr_t addr, uint64_t value)
 {
 	dsb();
+	isb();
 	*(volatile uint64_t*)addr = value;
 }
 
@@ -76,6 +81,7 @@ static inline uint64_t mmio_read_64(uintptr_t addr)
 
 	val = *(volatile uint64_t*)addr;
 	dsb();
+	isb();
 	return val;
 }
 

--- a/plat/hikey/bl1_plat_setup.c
+++ b/plat/hikey/bl1_plat_setup.c
@@ -296,6 +296,18 @@ static void hikey_hi6553_init(void)
 	/* enable LDO10 */
 	hi6553_write_8(ENABLE3_LDO9_16, 1 << 1);
 	mdelay(5);
+	/* enable LDO15 */
+	data = hi6553_read_8(LDO15_REG_ADJ);
+	data = (data & 0xf8) | 0x4;
+	hi6553_write_8(LDO15_REG_ADJ, data);
+	hi6553_write_8(ENABLE3_LDO9_16, 1 << 6);
+	mdelay(5);
+	/* enable LDO22 */
+	data = hi6553_read_8(LDO22_REG_ADJ);
+	data = (data & 0xf8) | 0x7;
+	hi6553_write_8(LDO22_REG_ADJ, data);
+	hi6553_write_8(ENABLE4_LDO17_22, 1 << 5);
+	mdelay(5);
 
 	/* select 32.764KHz */
 	hi6553_write_8(CLK19M2_600_586_EN, 0x01);

--- a/plat/hikey/include/hi6553.h
+++ b/plat/hikey/include/hi6553.h
@@ -47,6 +47,9 @@
 #define ENABLE3_LDO9_16				0x02c
 #define DISABLE3_LDO9_16			0x02d
 #define ONOFF_STATUS3_LDO9_16			0x02e
+#define ENABLE4_LDO17_22			0x02f
+#define DISABLE4_LDO17_22			0x030
+#define ONOFF_STATUS4_LDO17_22			0x031
 #define PERI_EN_MARK				0x040
 #define BUCK2_REG1				0x04a
 #define BUCK2_REG5				0x04e
@@ -64,8 +67,10 @@
 #define VSET_BUCK3_ADJ				0x06e
 #define LDO7_REG_ADJ				0x078
 #define LDO10_REG_ADJ				0x07b
+#define LDO15_REG_ADJ				0x080
 #define LDO19_REG_ADJ				0x084
 #define LDO20_REG_ADJ				0x085
+#define LDO22_REG_ADJ				0x087
 #define DR_LED_CTRL				0x098
 #define DR_OUT_CTRL				0x099
 #define DR3_ISET				0x09a


### PR DESCRIPTION
It's used to fix HDMI not working in kernel. Since all three LDOs on hdmi chip should be power on in 1 second. One of them is already power on after system reset. So the rests should be power on in the bootloader.

And append isb instruction when user access any register. It could avoid the unexpected exception on initializing DDR controller.
