### PR TITLE
hikey: enable BL3-0 for platform

### DIFF
--- a/plat/hikey/platform.mk
+++ b/plat/hikey/platform.mk
@@ -92,3 +92,5 @@ BL31_SOURCES		+=	drivers/arm/cci400/cci400.c		\
 				plat/hikey/drivers/sp804_timer.c	\
 				plat/hikey/plat_pm.c			\
 				plat/hikey/plat_topology.c
+
+NEED_BL30		:=	yes


### PR DESCRIPTION
Enable BL3-0 so that it will integrate mcuimage.bin into fip.

Signed-off-by: Leo Yan leo.yan@linaro.org
