### PR TITLE
plat: hikey: switch console to UART3

### DIFF
--- a/plat/hikey/aarch64/plat_helpers.S
+++ b/plat/hikey/aarch64/plat_helpers.S
@@ -45,7 +45,7 @@
 	.globl	platform_mem_init
 
 	/* Define a crash console for the plaform */
-#define HIKEY_CRASH_CONSOLE_BASE		PL011_UART0_BASE
+#define HIKEY_CRASH_CONSOLE_BASE		PL011_UART3_BASE
 
 	/* ---------------------------------------------
 	 * int plat_crash_console_init(void)
@@ -56,7 +56,7 @@
 	 */
 func plat_crash_console_init
 	mov_imm	x0, HIKEY_CRASH_CONSOLE_BASE
-	mov_imm	x1, PL011_UART0_CLK_IN_HZ
+	mov_imm	x1, PL011_UART_CLK_IN_HZ
 	mov_imm	x2, PL011_BAUDRATE
 	b	console_core_init
 

--- a/plat/hikey/bl1_plat_setup.c
+++ b/plat/hikey/bl1_plat_setup.c
@@ -87,7 +87,7 @@ void bl1_early_platform_setup(void)
 	const size_t bl1_size = BL1_RAM_LIMIT - BL1_RAM_BASE;
 
 	/* Initialize the console to provide early debug support */
-	console_init(PL011_UART0_BASE, PL011_UART0_CLK_IN_HZ, PL011_BAUDRATE);
+	console_init(PL011_UART3_BASE, PL011_UART_CLK_IN_HZ, PL011_BAUDRATE);
 
 	hi6220_timer_init();
 	/*

--- a/plat/hikey/bl2_plat_setup.c
+++ b/plat/hikey/bl2_plat_setup.c
@@ -176,7 +176,7 @@ void init_boardid(void)
 void bl2_early_platform_setup(meminfo_t *mem_layout)
 {
 	/* Initialize the console to provide early debug support */
-	console_init(PL011_UART0_BASE, PL011_UART0_CLK_IN_HZ, PL011_BAUDRATE);
+	console_init(PL011_UART3_BASE, PL011_UART_CLK_IN_HZ, PL011_BAUDRATE);
 
 	/* Setup the BL2 memory layout */
 	bl2_tzram_layout = *mem_layout;

--- a/plat/hikey/bl31_plat_setup.c
+++ b/plat/hikey/bl31_plat_setup.c
@@ -110,7 +110,7 @@ void bl31_early_platform_setup(bl31_params_t *from_bl2,
 			       void *plat_params_from_bl2)
 {
 	/* Initialize the console to provide early debug support */
-	console_init(PL011_UART0_BASE, PL011_UART0_CLK_IN_HZ, PL011_BAUDRATE);
+	console_init(PL011_UART3_BASE, PL011_UART_CLK_IN_HZ, PL011_BAUDRATE);
 
 	/*
 	 * Initialise the CCI-400 driver for BL31 so that it is accessible after

--- a/plat/hikey/hikey_def.h
+++ b/plat/hikey/hikey_def.h
@@ -80,10 +80,11 @@
  * PL011 related constants
  ******************************************************************************/
 #define PL011_UART0_BASE		0xF8015000
+#define PL011_UART3_BASE		0xF7113000
 
 #define PL011_BAUDRATE			115200
 
-#define PL011_UART0_CLK_IN_HZ		19200000
+#define PL011_UART_CLK_IN_HZ		19200000
 
 /*******************************************************************************
  * CCI-400 related constants


### PR DESCRIPTION
Switch serial console from UART0 to UART3. UART3 is on the LS
expansion interface of hikey board. UART0 port isn't installed
on most hikey boards.

Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
