### PR TITLE
Revert "plat: hikey: update syspll frequency"

### DIFF
--- a/plat/hikey/pll.c
+++ b/plat/hikey/pll.c
@@ -60,17 +60,6 @@ static void init_pll(void)
 		data = mmio_read_32((0xf7800000 + 0x014));
 		data &= 0x007;
 	} while (data != 0x004);
-
-	mmio_write_32(PERI_SC_PERIPH_CTRL14, 0x2101);
-	data = mmio_read_32(PERI_SC_PERIPH_STAT1);
-	mmio_write_32(0xf7032000 + 0x02c, 0x5110103e);
-	data = mmio_read_32(0xf7032000 + 0x050);
-	data |= 1 << 28;
-	mmio_write_32(0xf7032000 + 0x050, data);
-	mmio_write_32(PERI_SC_PERIPH_CTRL14, 0x2101);
-	mdelay(1);
-	data = mmio_read_32(PERI_SC_PERIPH_STAT1);
-	NOTICE("syspll frequency:%dHz\n", data);
 }
 
 static void init_freq(void)


### PR DESCRIPTION
Reverts 96boards/arm-trusted-firmware#46

syspll clock changes requires changes on the bootloader and the kernel. Kernel changes not being ready yet, bootloader changes only are introducing a regression. Revert until the kernel changes are sorted out and both bootloader/kernel changes can goes in at the same time.
