### PR TITLE
hikey: make console and crash console configurable

### DIFF
--- a/plat/hikey/aarch64/plat_helpers.S
+++ b/plat/hikey/aarch64/plat_helpers.S
@@ -44,9 +44,6 @@
 	.globl	platform_get_core_pos
 	.globl	platform_mem_init
 
-	/* Define a crash console for the plaform */
-#define HIKEY_CRASH_CONSOLE_BASE		PL011_UART3_BASE
-
 	/* ---------------------------------------------
 	 * int plat_crash_console_init(void)
 	 * Function to initialize the crash console
@@ -55,7 +52,7 @@
 	 * ---------------------------------------------
 	 */
 func plat_crash_console_init
-	mov_imm	x0, HIKEY_CRASH_CONSOLE_BASE
+	mov_imm	x0, CRASH_CONSOLE_BASE
 	mov_imm	x1, PL011_UART_CLK_IN_HZ
 	mov_imm	x2, PL011_BAUDRATE
 	b	console_core_init
@@ -68,7 +65,7 @@ func plat_crash_console_init
 	 * ---------------------------------------------
 	 */
 func plat_crash_console_putc
-	mov_imm	x1, HIKEY_CRASH_CONSOLE_BASE
+	mov_imm	x1, CRASH_CONSOLE_BASE
 	b	console_core_putc
 
 	/* ---------------------------------------------

--- a/plat/hikey/bl1_plat_setup.c
+++ b/plat/hikey/bl1_plat_setup.c
@@ -87,7 +87,7 @@ void bl1_early_platform_setup(void)
 	const size_t bl1_size = BL1_RAM_LIMIT - BL1_RAM_BASE;
 
 	/* Initialize the console to provide early debug support */
-	console_init(PL011_UART3_BASE, PL011_UART_CLK_IN_HZ, PL011_BAUDRATE);
+	console_init(CONSOLE_BASE, PL011_UART_CLK_IN_HZ, PL011_BAUDRATE);
 
 	hi6220_timer_init();
 	/*

--- a/plat/hikey/bl2_plat_setup.c
+++ b/plat/hikey/bl2_plat_setup.c
@@ -176,7 +176,7 @@ void init_boardid(void)
 void bl2_early_platform_setup(meminfo_t *mem_layout)
 {
 	/* Initialize the console to provide early debug support */
-	console_init(PL011_UART3_BASE, PL011_UART_CLK_IN_HZ, PL011_BAUDRATE);
+	console_init(CONSOLE_BASE, PL011_UART_CLK_IN_HZ, PL011_BAUDRATE);
 
 	/* Setup the BL2 memory layout */
 	bl2_tzram_layout = *mem_layout;

--- a/plat/hikey/bl31_plat_setup.c
+++ b/plat/hikey/bl31_plat_setup.c
@@ -110,7 +110,7 @@ void bl31_early_platform_setup(bl31_params_t *from_bl2,
 			       void *plat_params_from_bl2)
 {
 	/* Initialize the console to provide early debug support */
-	console_init(PL011_UART3_BASE, PL011_UART_CLK_IN_HZ, PL011_BAUDRATE);
+	console_init(CONSOLE_BASE, PL011_UART_CLK_IN_HZ, PL011_BAUDRATE);
 
 	/*
 	 * Initialise the CCI-400 driver for BL31 so that it is accessible after

--- a/plat/hikey/platform.mk
+++ b/plat/hikey/platform.mk
@@ -41,8 +41,13 @@ else
   $(error "Unsupported PLAT_TSP_LOCATION value")
 endif
 
+CONSOLE_BASE		:=	PL011_UART3_BASE
+CRASH_CONSOLE_BASE	:=	PL011_UART3_BASE
+
 # Process flags
 $(eval $(call add_define,PLAT_TSP_LOCATION_ID))
+$(eval $(call add_define,CONSOLE_BASE))
+$(eval $(call add_define,CRASH_CONSOLE_BASE))
 
 
 PLAT_INCLUDES		:=	-Iplat/hikey/include/


### PR DESCRIPTION
The UART used by BL1/BL2/BL31 can be chosen with CONSOLE_BASE.
The crash console can be chosen with CRASH_CONSOLE_BASE.
For instance:

  make PLAT=hikey \
       CROSS_COMPILE=aarch64-linux-gnu- \
       CONSOLE_BASE=PL011_UART0_BASE \
       CRASH_CONSOLE_BASE=PL011_UART0_BASE

Signed-off-by: Jerome Forissier jerome.forissier@linaro.org
