### PR TITLE
hikey: sn: force to generate new SN

### DIFF
--- a/plat/hikey/bl1_plat_setup.c
+++ b/plat/hikey/bl1_plat_setup.c
@@ -196,7 +196,7 @@ static uint64_t rand(unsigned int data)
 	return (t % ((uint64_t)RANDOM_MAX + 1));
 }
 
-static void generate_serialno(struct random_serial_num *random)
+void generate_serialno(struct random_serial_num *random)
 {
 	unsigned int data, t;
 	int i;

--- a/plat/hikey/hikey_private.h
+++ b/plat/hikey/hikey_private.h
@@ -77,6 +77,7 @@ extern int flush_loader_image(void);
 extern int flush_user_images(char *cmdbuf, unsigned long addr,
 			     unsigned long length);
 extern int flush_random_serialno(unsigned long addr, unsigned long length);
+extern void generate_serialno(struct random_serial_num *random);
 extern char *load_serialno(void);
 extern void hi6220_pll_init(void);
 extern void io_setup(void);

--- a/plat/hikey/usb.c
+++ b/plat/hikey/usb.c
@@ -1278,6 +1278,14 @@ static unsigned long strtoul(const char *nptr, char **endptr, int base)
 	return data;
 }
 
+static void fb_serialno(char *cmdbuf)
+{
+	struct random_serial_num random;
+
+	generate_serialno(&random);
+	flush_random_serialno((unsigned long)&random, sizeof(random));
+}
+
 #define FB_DOWNLOAD_BASE	0x20000000
 
 static unsigned long fb_download_base, fb_download_size;
@@ -1350,6 +1358,10 @@ static void usb_rx_cmd_complete(unsigned actual, int stat)
 	} else if(memcmp(cmdbuf, (void *)"boot", 4) == 0) {
 		INFO(" - OKAY\n");
 
+		return;
+	} else if (memcmp(cmdbuf, (void *)"oem serialno", 12) == 0) {
+		fb_serialno(cmdbuf);
+		tx_status("OKAY");
 		return;
 	}
 


### PR DESCRIPTION
Provide the command to generate SN forcely.
$sudo fastboot oem serialno

Then reboot the board, a new SN is used for fastboot protocol.

Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
