### PR TITLE
hikey: enable SYSTEM_OFF in PSCI

### DIFF
--- a/plat/hikey/bl1_plat_setup.c
+++ b/plat/hikey/bl1_plat_setup.c
@@ -405,6 +405,10 @@ static void hikey_gpio_init(void)
 	gpio_direction_output(33);
 	gpio_direction_output(34);
 	gpio_direction_output(35);
+
+	/* Initialize PWR_HOLD GPIO */
+	gpio_set_value(0, 1);
+	gpio_direction_output(0);
 }
 
 /*******************************************************************************


### PR DESCRIPTION
Enable power down feature in PSCI. Pull down PWR_HOLD_GPIO pin.
If fails to operate the GPIO pin, it'll trigger system reset
after 1 second.

Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
