### PR TITLE
hikey: fix build issue missing gpio

### DIFF
--- a/plat/hikey/platform.mk
+++ b/plat/hikey/platform.mk
@@ -91,6 +91,7 @@ BL31_SOURCES		+=	drivers/arm/cci400/cci400.c		\
 				drivers/arm/gic/arm_gic.c		\
 				drivers/arm/gic/gic_v2.c		\
 				drivers/arm/gic/gic_v3.c		\
+				drivers/arm/gpio/gpio.c			\
 				lib/cpus/aarch64/cortex_a53.S		\
 				plat/common/aarch64/platform_mp_stack.S	\
 				plat/hikey/bl31_plat_setup.c		\


### PR DESCRIPTION
./build/hikey/release/bl31/plat_pm.o: In function `hikey_system_off':
plat_pm.c:(.text.hikey_system_off+0x10): undefined reference to
`gpio_set_value'
make: **\* [build/hikey/release/bl31/bl31.elf] Error 1

After appending gpio driver in platform.mk, this issue could be fixed.

Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
