### PR TITLE
hikey: fix the partition entry size

### DIFF
--- a/plat/hikey/include/partitions.h
+++ b/plat/hikey/include/partitions.h
@@ -36,8 +36,8 @@
 #define EFI_NAMELEN			36
 
 struct ptentry {
-	unsigned int	start;
-	unsigned int	length;
+	uint64_t	start;
+	uint64_t	length;
 	unsigned int	flags;
 	unsigned int	loadaddr;
 	unsigned int	loadsize;

--- a/plat/hikey/partitions.c
+++ b/plat/hikey/partitions.c
@@ -121,8 +121,8 @@ static int parse_entry(uintptr_t buf)
 	ret = convert_ascii_string(entry->name, (uint8_t *)ptable[entries].name);
 	if (ret < 0)
 		return ret;
-	ptable[entries].start = entry->first_lba * 512;
-	ptable[entries].length = (entry->last_lba - entry->first_lba + 1) * 512;
+	ptable[entries].start = (uint64_t)entry->first_lba * 512;
+	ptable[entries].length = (uint64_t)(entry->last_lba - entry->first_lba + 1) * 512;
 	entries++;
 	return 0;
 }

--- a/plat/hikey/plat_io_storage.c
+++ b/plat/hikey/plat_io_storage.c
@@ -323,7 +323,7 @@ int update_fip_spec(void)
 			return IO_FAIL;
 		}
 	}
-	VERBOSE("%s: name:%s, start:%x, length:%x\n",
+	VERBOSE("%s: name:%s, start:%llx, length:%llx\n",
 		__func__, ptn->name, ptn->start, ptn->length);
 	fip_block_spec.offset = ptn->start;
 	fip_block_spec.length = ptn->length;
@@ -487,9 +487,10 @@ static int do_unsparse(char *cmdbuf, unsigned long img_addr, unsigned long img_l
 	chunk_header_t *chunk = NULL;
 	struct ptentry *ptn;
 	void *data = (void *)img_addr;
-	uint32_t length, out_blks = 0, out_length = 0;
+	uint64_t out_blks = 0, out_length = 0;
+	uint64_t length;
 	uint32_t fill_value;
-	uint32_t left, count;
+	uint64_t left, count;
 	int i, result;
 
 	ptn = find_ptn(cmdbuf);
@@ -497,9 +498,9 @@ static int do_unsparse(char *cmdbuf, unsigned long img_addr, unsigned long img_l
 		NOTICE("failed to find partition %s\n", cmdbuf);
 		return IO_FAIL;
 	}
-	length = header->total_blks * header->blk_sz;
+	length = (uint64_t)(header->total_blks) * (uint64_t)(header->blk_sz);
 	if (length > ptn->length) {
-		NOTICE("Unsparsed image length is %d, pentry length is %d.\n",
+		NOTICE("Unsparsed image length is %lld, pentry length is %lld.\n",
 			length, ptn->length);
 		return IO_FAIL;
 	}
@@ -508,7 +509,7 @@ static int do_unsparse(char *cmdbuf, unsigned long img_addr, unsigned long img_l
 	for (i = 0; i < header->total_chunks; i++) {
 		chunk = (chunk_header_t *)data;
 		data = (void *)((unsigned long)data + sizeof(chunk_header_t));
-		length = chunk->chunk_sz * header->blk_sz;
+		length = (uint64_t)chunk->chunk_sz * (uint64_t)header->blk_sz;
 
 		switch (chunk->chunk_type) {
 		case CHUNK_TYPE_RAW:


### PR DESCRIPTION
The size or start of each partition should be counted as 64bit, not
32bit. Otherwise, can't recognize any partition larger than 4GB well.

Signed-off-by: Haojian Zhuang haojian.zhuang@linaro.org
