### PR TITLE
arm-trusted-firmware: Fixup fastboot getvar hang on unknown variable

### DIFF
--- a/plat/hikey/usb.c
+++ b/plat/hikey/usb.c
@@ -1248,6 +1248,12 @@ static void fb_getvar(char *cmdbuf)
 		response[bytes] = '\0';
 		tx_status(response);
 		rx_cmd();
+	} else {
+		bytes = sprintf(response, "FAIL%s",
+					"unknown var");
+		response[bytes] = '\0';
+		tx_status(response);
+		rx_cmd();
 	}
 }
 


### PR DESCRIPTION
The fastboot implementation doesn't return an error if it hits
a varable it doesn't know. This results in host's fastboot hanging
if it tries to query for an unsupported variable.

This patch addresses this by returning an error in the case
that the var is unkonwn.

Signed-off-by: John Stultz john.stultz@linaro.org
